### PR TITLE
Broken symlink

### DIFF
--- a/bin/phpspec
+++ b/bin/phpspec
@@ -1,1 +1,0 @@
-../vendor/phpspec/phpspec/bin/phpspec


### PR DESCRIPTION
This symlink is broken for the installed version. Looks like you need this for composer on local development. If so, why not create it on composer install of this project if you like it so much?